### PR TITLE
galaxys2-common: Set low_ram active again

### DIFF
--- a/go_galaxys2-common.mk
+++ b/go_galaxys2-common.mk
@@ -18,7 +18,7 @@
 
 # Set lowram options
 PRODUCT_PROPERTY_OVERRIDES += \
-     ro.config.low_ram=false \
+     ro.config.low_ram=true \
      ro.lmk.critical_upgrade=true \
      ro.lmk.upgrade_pressure=40 \
      ro.lmk.downgrade_pressure=60 \


### PR DESCRIPTION
Since our libMali.so has troubles and need a hack in framworks_base
repository because of crashes when display fade-out effect starts,
we need to set low_ram active so the animation is disabled.

Change-Id: I2f951c821081242bcec3efc139ac5f32ad2c2d07