### PR TITLE
galaxys2-common: PinnerService: Don't keep camera and home app

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -200,10 +200,10 @@
     </string-array>
 
     <!-- Keep chosen default camera app pinned in memory for faster launching -->
-    <bool name="config_pinnerCameraApp">true</bool>
+    <bool name="config_pinnerCameraApp">false</bool>
 
     <!-- Keep home app pinned in memory for faster launching -->
-    <bool name="config_pinnerHomeApp">true</bool>
+    <bool name="config_pinnerHomeApp">false</bool>
 
     <!-- Whether UI for multi user should be shown -->
     <bool name="config_enableMultiUserUI">true</bool>


### PR DESCRIPTION
Free memory as much as possible for other apps.

Change-Id: Ib84b6522df09fb8b2857e3d22f2fcbbc2fdb38f4