### PR TITLE
galaxys2-common: Set ro.config.small_battery to true

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -83,6 +83,11 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     android.hardware.power@1.0-service.exynos4
 
+# Battery
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.config.small_battery=true
+
+
 # Audio Packages
 PRODUCT_PACKAGES += \
     android.hardware.audio@2.0-impl \


### PR DESCRIPTION
Our device has a small battery of 1650mAh compared to >3000mAh of
today devices. Effectively this will trigger device-idle in 15
minutes instead of 30 minutes (Inactive-timeout and
Idle-after-inactive-timeout).

Change-Id: Ib7317815d5c051cd467ea5570ee51c1cb616c2ee